### PR TITLE
Fixed URI error

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Code Example
 ----
 Please review the [API Documentation](https://developers.nodecraft.com) for more details on specific operations and acquiring an API key.
 ```
-  var api = require('./index.js')('username', 'xxxxx-xxxxx-xxxxx-xxxxx');
+  var api = require('nodecraft-api')('username', 'xxxxx-xxxxx-xxxxx-xxxxx');
   api.services.list(console.log);
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = function(username, apiKey, version){
 	var request = require('request'),
-		url = 'http://api.nodecraft.com',
+		url = 'http://api.nodecraft.com/',
 		version = version || 'v1',
 		auth = {
 			username: username,


### PR DESCRIPTION
In response to this error-

`{ Error: getaddrinfo ENOTFOUND api.nodecraft.comv1 api.nodecraft.comv1:80
    at errnoException (dns.js:28:10)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:79:26)
  code: 'ENOTFOUND',
  errno: 'ENOTFOUND',
  syscall: 'getaddrinfo',
  hostname: 'api.nodecraft.comv1',
  host: 'api.nodecraft.comv1',
  port: 80 }`
